### PR TITLE
Move keystore into tools/ and keep/use for future signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+tools/
+*.apk

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
-tools/
+# Downloaded and built application files
 *.apk
+*.html
+*.log
+
+# Downloaded tools
+tools/
+
+# Internal stuff
+.??*

--- a/APK/com.freestylelibre.app.de_2019-04-22.apk.sha1
+++ b/APK/com.freestylelibre.app.de_2019-04-22.apk.sha1
@@ -1,0 +1,1 @@
+fde97bd01a374b0bcd83290cd9390bd4c36d5bac  APK/com.freestylelibre.app.de_2019-04-22.apk

--- a/APK/com.freestylelibre.app.de_2020-02-15.apk.sha1
+++ b/APK/com.freestylelibre.app.de_2020-02-15.apk.sha1
@@ -1,0 +1,1 @@
+f59626533602071698e990ca1893227f725b8a83  APK/com.freestylelibre.app.de_2020-02-15.apk

--- a/download.sh
+++ b/download.sh
@@ -9,6 +9,7 @@ YELLOW='\033[1;33m'
 
 WORKDIR=$(pwd)
 FILENAME='com.freestylelibre.app.de_2019-04-22'
+#FILENAME='com.freestylelibre.app.de_2020-02-15'
 
 # wget HSTS-bugfix for debian as subsystem in Windows
 touch ~/.wget-hsts
@@ -16,6 +17,8 @@ chmod 644 ~/.wget-hsts
 
 echo -e "${WHITE}Lade original APK herunter ...${NORMAL}"
 wget -O APK/apkpure.html --keep-session-cookies --save-cookies cookies.txt https://apkpure.com/de/freestyle-librelink-de/com.freestylelibre.app.de/download/4751-APK
+#wget -O APK/apkpure.html --keep-session-cookies --save-cookies cookies.txt https://apkpure.com/de/freestyle-librelink-de/com.freestylelibre.app.de/download/5417-APK
+
 URL=$(grep "hier klicken" APK/apkpure.html | sed 's#^.*https://##' | sed 's/">.*//')
 wget -O APK/${FILENAME}.apk --load-cookies cookies.txt https://${URL}
 if [ $? = 0 ]; then

--- a/patch.sh
+++ b/patch.sh
@@ -75,8 +75,16 @@ else
   exit 1
 fi
 
-echo -e "${WHITE}Prüfe MD5 Summe der APK Datei ...${NORMAL}"
-md5sum -c APK/${FILENAME}.apk.md5 > /dev/null 2>&1
+if [ -f APK/${FILENAME}.apk.md5 ]; then
+  echo -e "${WHITE}Prüfe MD5 Summe der APK Datei ...${NORMAL}"
+  md5sum -c APK/${FILENAME}.apk.md5 > /dev/null 2>&1
+elif [ -f APK/${FILENAME}.apk.sha1 ]; then
+  echo -e "${WHITE}Prüfe SHA1 Summe der APK Datei ...${NORMAL}"
+  sha1sum -c APK/${FILENAME}.apk.sha1 > /dev/null 2>&1
+else
+  echo -e "${YELLOW}Keine Prüfung der APK Datei ...${NORMAL}"
+  true
+fi
 if [ $? = 0 ]; then
   echo -e "${GREEN}  okay.${NORMAL}"
   echo

--- a/patch.sh
+++ b/patch.sh
@@ -180,30 +180,34 @@ else
   exit 1
 fi
 
-echo -e "${WHITE}Erstelle Keystore zum Signieren der gepatchten APK Datei ...${NORMAL}"
-keytool -genkey -v -keystore /tmp/libre-keystore.p12 -storetype PKCS12 -alias "Libre Signer" -keyalg RSA -keysize 2048 --validity 10000 --storepass geheim --keypass geheim -dname "cn=Libre Signer, c=de"
-if [ $? = 0 ]; then
+if [ ! -f tools/libre-keystore.p12 ]; then
+ echo -e "${WHITE}Erstelle Keystore zum Signieren der gepatchten APK Datei ...${NORMAL}"
+ keytool -genkey -v -keystore tools/libre-keystore.p12 -storetype PKCS12 -alias "Libre Signer" -keyalg RSA -keysize 2048 --validity 10000 --storepass geheim --keypass geheim -dname "cn=Libre Signer, c=de"
+ if [ $? = 0 ]; then
   echo -e "${GREEN}  okay.${NORMAL}"
   echo
-else
+ else
   echo -e "${RED}  nicht okay.${NORMAL}"
   echo
   echo -e "${YELLOW}=> Bitte prüfen Sie o.a. Fehler.${NORMAL}"
   exit 1
+ fi
+else
+ echo -e "${WHITE}Verwende existierenden Keystore zum Signieren der gepatchten APK Datei ...${NORMAL}"
 fi
 
 echo -e "${WHITE}Signiere gepatchte APK Datei ...${NORMAL}"
 if [ -x /usr/lib/android-sdk/build-tools/debian/apksigner.jar ]; then
-  java -jar /usr/lib/android-sdk/build-tools/debian/apksigner.jar sign --ks-pass pass:geheim --ks /tmp/libre-keystore.p12 APK/${FILENAME}_patched.apk
+  java -jar /usr/lib/android-sdk/build-tools/debian/apksigner.jar sign --ks-pass pass:geheim --ks tools/libre-keystore.p12 APK/${FILENAME}_patched.apk
 elif [ -x /usr/share/apksigner/apksigner.jar ]; then
-  java -jar /usr/share/apksigner/apksigner.jar sign --ks-pass pass:geheim --ks /tmp/libre-keystore.p12 APK/${FILENAME}_patched.apk
+  java -jar /usr/share/apksigner/apksigner.jar sign --ks-pass pass:geheim --ks tools/libre-keystore.p12 APK/${FILENAME}_patched.apk
 else
-  apksigner sign --ks-pass pass:geheim --ks /tmp/libre-keystore.p12 APK/${FILENAME}_patched.apk
+  apksigner sign --ks-pass pass:geheim --ks tools/libre-keystore.p12 APK/${FILENAME}_patched.apk
 fi
 if [ $? = 0 ]; then
   echo -e "${GREEN}  okay.${NORMAL}"
   echo
-  rm /tmp/libre-keystore.p12
+  # libre-keystore.p12 nicht entfernen!
 else
   echo -e "${RED}  nicht okay.${NORMAL}"
   echo


### PR DESCRIPTION
The English instructions suggest to preserve the keystore, and indeed to upgrade the app in-place (if there's a new patch set, or a new apk version), it makes sense to keep the file (it's got a lifetime of 10000 days).
This diff moves the `libre-keystore.p12` file from `/tmp` into the `tools` directory.
I deliberately violated your indentation rules to make it more readable.
Feel free to use, reformat, or ignore.